### PR TITLE
rename blog title to stenyan.dev

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "/^(fa){3}$/",
-  "short_name": "/^(fa){3}$/",
+  "name": "stenyan.dev",
+  "short_name": "stenyan.dev",
   "icons": [
     {
       "src": "/android-chrome-192x192.png",

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -13,7 +13,7 @@ export type Link = {
 }
 
 export const SITE: Site = {
-  TITLE: '/^(fa){3}$/',
+  TITLE: 'stenyan.dev',
   DESCRIPTION: 'すてにゃん (stefafafan) によるテックブログです。',
   NUM_POSTS_ON_HOMEPAGE: 5,
   POSTS_PER_PAGE: 5,


### PR DESCRIPTION
`/^(fa){3}$/` is hard to read and on Google search is shown as so, not so cool 🤔 
![CleanShot 2025-03-29 at 23 24 28@2x](https://github.com/user-attachments/assets/edc15223-b163-43aa-ba1c-fbdc35c7e51e)
