### PR TITLE
サイト名の . を [.] にする

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "stenyan.dev",
-  "short_name": "stenyan.dev",
+  "name": "stenyan[.]dev",
+  "short_name": "stenyan[.]dev",
   "icons": [
     {
       "src": "/android-chrome-192x192.png",

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -13,7 +13,7 @@ export type Link = {
 }
 
 export const SITE: Site = {
-  TITLE: 'stenyan.dev',
+  TITLE: 'stenyan[.]dev',
   DESCRIPTION: 'すてにゃん (stefafafan) によるテックブログです。',
   NUM_POSTS_ON_HOMEPAGE: 5,
   POSTS_PER_PAGE: 5,


### PR DESCRIPTION
特定記事のシェア時に stenyan.dev が展開されてしまうのを避ける

