### PR TITLE
stickyなヘッダーをやめる

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -9,7 +9,6 @@ import logo from '../../public/static/logo.png'
 ---
 
 <header
-  class="sticky top-0 z-10 bg-background/50 backdrop-blur-md"
   transition:persist
 >
   <Container>


### PR DESCRIPTION
スマホなど画面幅が狭い時はないほうが良さそう